### PR TITLE
Include ATCA trigger functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .eggs
 trigger_webapp/trigger_app/migrations/
 tests/_trial_temp/
+.voevent_env/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 trigger_webapp/trigger_app/migrations/
 tests/_trial_temp/
 .voevent_env/
+settings.json

--- a/mwa_trigger/triggerservice.py
+++ b/mwa_trigger/triggerservice.py
@@ -483,8 +483,8 @@ def trigger_atca(
         The logger to use.
     """
 
-    ra_str = Angle(ra * u.deg).to_string(sep=":")
-    dec_str = Angle(dec * u.deg).to_string(sep=":")
+    ra_str = Angle(ra * u.deg).to_string(unit=u.hour, sep=":")
+    dec_str = Angle(dec * u.deg).to_string(unit=u.deg, sep=":")
 
     schedule = cabb.schedule()
     # currentFreqs = cabb.monica_information.getFrequencies()

--- a/mwa_trigger/triggerservice.py
+++ b/mwa_trigger/triggerservice.py
@@ -505,7 +505,7 @@ def trigger_atca(
     currentArray = cabb.monica_information.getArray()
     bestCal = calList.getBestCalibrator(currentArray)
     logger.info(
-        f"Calibrator chosen: {bestCal['calibrator'].getName():%s}, {bestCal['distance']:%.1f} degrees away"
+        f"Calibrator chosen: {bestCal['calibrator'].getName():s}, {bestCal['distance']:.1f} degrees away"
     )
     calScan = schedule.addCalibrator(
         bestCal["calibrator"],
@@ -518,8 +518,8 @@ def trigger_atca(
 
     schedule.setLooping(False)
 
-    if logger.is_enabled_for(logging.DEBUG):
-        fname = strftime("%Y-%m-%d-T%H:%M", gmtime())
+    if pretend:
+        fname = strftime("%Y-%m-%d_%H%M", gmtime())
         fname = f"{project_id}_{fname}.sch"
         schedule.write(name=fname)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+astropy
+numpy
+Comet
+git+https://github.com/4pisky/fourpiskytools.git
+git+https://github.com/ste616/atca-rapid-response-api.git#subdirectory=python
+git+https://github.com/ste616/cabb-schedule-api.git#subdirectory=python


### PR DESCRIPTION
- Create a function `trigger_atca` based on examples from [vo_atca](https://github.com/mebell/vo_atca).
  - Re-use as many of the parameters from `trigger` as are useful an applicable
- Create a wrapper function `trigger_mwa` that calls `trigger` (for naming consistency)
- Update `requirements.txt` to include [fourpiskytools](https://github.com/4pisky/fourpiskytools), [cabb_schedule_api](https://github.com/ste616/cabb-schedule-api), and [atca_rapid_response_api](https://github.com/ste616/atca-rapid-response-api/tree/master/python).
- Enforce PEP with `black` (unintentionally!)
