### PR TITLE
(partial) solve for missing events

### DIFF
--- a/webapp_tracet/twistd_comet_wrapper.py
+++ b/webapp_tracet/twistd_comet_wrapper.py
@@ -59,7 +59,7 @@ if __name__ == '__main__':
 
 
     logger.info("Starting twistd command:")
-    twistd_commad = f"twistd --pidfile /tmp/twistd_comet.pid -n comet --local-ivo=ivo://hotwired.org/test {remote_command} --cmd=upload_xml.py"
+    twistd_commad = f"twistd --pidfile /tmp/twistd_comet.pid -n comet --local-ivo=ivo://tracet.duckdns.org/trigger {remote_command} --cmd=upload_xml.py"
     logger.info(twistd_commad)
     process = Popen(twistd_commad, shell=True, stdout=PIPE)
     # get initial output right away
@@ -69,7 +69,7 @@ if __name__ == '__main__':
     scheduler = BackgroundScheduler(timezone=settings.TIME_ZONE)
     scheduler.add_job(
         output_popen_stdout,
-        trigger=CronTrigger(second="*/59"),  # Every 60 seconds
+        trigger=CronTrigger(second="*/5"),  # Every 5 seconds
         id="output_popen_stdout",
         max_instances=1,
         replace_existing=True,

--- a/webapp_tracet/webapp_tracet/settings.py
+++ b/webapp_tracet/webapp_tracet/settings.py
@@ -24,9 +24,9 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 ALLOWED_HOSTS = ['127.0.0.1', 'localhost', 'www.mwa-trigger.duckdns.org', 'mwa-trigger.duckdns.org', 'www.tracet.duckdns.org', 'tracet.duckdns.org', '146.118.70.58']
 
 # Remote broadcasters we subscribe to for VOEvents
-VOEVENT_REMOTES = ["voevent.4pisky.org"]
+VOEVENT_REMOTES = ["voevent.4pisky.org","voevent.dc3.com"]
 # TCP connectiong we are whitelisting with to recieve VOEvents
-VOEVENT_TCP = ["196.44.140.214/32"]
+VOEVENT_TCP = ["196.44.140.214/32","68.169.57.253","50.116.49.68"]
 
 
 # Application definition


### PR DESCRIPTION
Reduce the missing event rate from ~25% to around 1% by subscribing to multiple voevent brokers, as per #97 recommendation.

Update the local ivo name (seems to make no difference).

Read comet logs every 5 seconds in order to keep the log more up to date (#111).